### PR TITLE
Prevents Filebot attempting every file downloaded by Deluge

### DIFF
--- a/bash/deluge-postprocess.sh
+++ b/bash/deluge-postprocess.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Input Parameters
-ARG_PATH="$3"
+ARG_PATH="$3$2"
 ARG_NAME="$2"
 ARG_LABEL="N/A"
 


### PR DESCRIPTION
This was causing Filebot to put files in the .excludes before they were complete and half uploaded files being put on Plex.

As it would do:

```
ut_dir = /deluge/download/
ut_title = filedirectoryname
```

rather than:

```
ut_dir = /deluge/download/filedirectoryname
ut_title = filedirectoryname
```
