### PR TITLE
Ignore files with mime-type inode/x-empty

### DIFF
--- a/docker/filebot-watcher
+++ b/docker/filebot-watcher
@@ -2,11 +2,8 @@
 
 inotifywait -m "$1" -e create -e moved_to -e modify --exclude '/[.@]' --format '%w%f' | stdbuf -oL uniq | while read -r FILE; do
 	# file may yield inode/x-empty for new files
-	sleep 2
-
-	# abort if the file has been modified while we were asleep
-	if [ `find "$FILE" -type f -newermt '2 seconds ago' -print -quit` ]; then
-		echo "Modified: $FILE"
+        if file --mime-type "$FILE" | egrep "inode/x-empty"; then
+        	echo "Empty file: $FILE"
 		continue
 	fi
 


### PR DESCRIPTION
When I move a newly created folder with a video file in it to the watched folder,
  it is caught by the '2 seconds ago' checker and
  the folder (and its contents, because ```inotifywait``` is non-recursive) is ignored.

This patch instead checks if the mime-type is ```inode/x-empty``` and
  only ignores those files.