### PR TITLE
Update package version in tar.sh (4.8.2 -> 4.8.5)

### DIFF
--- a/installer/tar.sh
+++ b/installer/tar.sh
@@ -1,11 +1,10 @@
 #!/bin/sh -xu
 
-PACKAGE_VERSION=4.8.2
+PACKAGE_VERSION=4.8.5
 PACKAGE_SHA256=$(curl -fsSL https://raw.githubusercontent.com/filebot/website/master/get.filebot.net/filebot/FileBot_$PACKAGE_VERSION/FileBot_$PACKAGE_VERSION-portable.tar.xz.sha256)
 
 PACKAGE_FILE=FileBot_$PACKAGE_VERSION-portable.tar.xz
 PACKAGE_URL=https://get.filebot.net/filebot/FileBot_$PACKAGE_VERSION/$PACKAGE_FILE
-
 
 # Download latest portable package
 curl -o "$PACKAGE_FILE" -z "$PACKAGE_FILE" "$PACKAGE_URL"


### PR DESCRIPTION
Any reason this shouldn't be pointing to 4.8.5 now? 