### PR TITLE
Added -y switch to install commands

### DIFF
--- a/installer/deb.sh
+++ b/installer/deb.sh
@@ -4,7 +4,7 @@
 uname -a
 
 # 0. Install pre-requisites
-sudo apt-get install --install-recommends dirmngr gnupg-curl apt-transport-https
+sudo apt-get install -y --install-recommends dirmngr gnupg-curl apt-transport-https
 
 # 1. Import signing keys
 curl -fsSL "https://raw.githubusercontent.com/filebot/plugins/master/gpg/maintainer.pub" | sudo gpg --dearmor --output "/usr/share/keyrings/filebot.gpg"
@@ -16,10 +16,10 @@ echo "deb [signed-by=/usr/share/keyrings/filebot.gpg] https://get.filebot.net/de
 sudo apt-get update
 
 # 4. Install dependencies explicitly (otherwise apt-get autoremove may purge them)
-sudo apt-get install --install-recommends default-jre openjfx zenity mediainfo libchromaprint-tools p7zip-full unrar
+sudo apt-get install -y --install-recommends default-jre openjfx zenity mediainfo libchromaprint-tools p7zip-full unrar
 
 # 5. Install FileBot
-sudo apt-get install --install-recommends filebot
+sudo apt-get install -y --install-recommends filebot
 
 # 6. Test Run
 filebot -script fn:sysinfo


### PR DESCRIPTION
To fix install from being aborted and having to independently run `sudo apt install filebot` as indicated below...
```bash
The following NEW packages will be installed:
  alsa-topology-conf alsa-ucm-conf aspell aspell-en bubblewrap ca-certificates-java default-jre
  default-jre-headless dictionaries-common enchant-2 filebot fonts-dejavu-extra glib-networking
  glib-networking-common glib-networking-services gstreamer1.0-gl gstreamer1.0-plugins-base
  gstreamer1.0-plugins-good gstreamer1.0-x hunspell-en-us i965-va-driver intel-media-va-driver java-common
  libaa1 libaacs0 libaom3 libasound2 libasound2-data libaspell15 libasyncns0 libatk-wrapper-java
  libatk-wrapper-java-jni libavc1394-0 libavcodec58 libavformat58 libavutil56 libbdplus0 libbluray2
  libcaca0 libcanberra0 libcdparanoia0 libchromaprint-tools libchromaprint1 libcodec2-1.0 libdav1d5
  libdrm-amdgpu1 libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libdv4 libegl-mesa0 libegl1 libenchant-2-2
  libevdev2 libflac8 libfontenc1 libgbm1 libgif7 libgl1 libgl1-amber-dri libgl1-mesa-dri libglapi-mesa
  libglvnd0 libglx-mesa0 libglx0 libgme0 libgraphene-1.0-0 libgsm1 libgstreamer-gl1.0-0
  libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libhunspell-1.7-0 libhyphen0 libice6
  libiec61883-0 libigdgmm12 libjack-jackd2-0 libjavascriptcoregtk-4.0-18 libjna-java libjna-jni libllvm13
  libmanette-0.2-0 libmediainfo0v5 libmfx1 libmms0 libmpg123-0 libnorm1 libnotify4 libopengl0 libopenjp2-7
  libopenmpt0 liborc-0.4-0 libpciaccess0 libpcsclite1 libpgm-5.3-0 libpipewire-0.3-0
  libpipewire-0.3-common libpipewire-0.3-modules libproxy1v5 libpulse0 librabbitmq4 libraw1394-11
  libsamplerate0 libsecret-1-0 libsecret-common libsensors-config libsensors5 libshine3 libshout3 libsm6
  libsnappy1v5 libsndfile1 libsoup2.4-1 libsoup2.4-common libsoxr0 libspa-0.2-modules libspeex1
  libsrt1.4-gnutls libssh-gcrypt-4 libswresample3 libtag1v5 libtag1v5-vanilla libtdb1 libtheora0
  libtinyxml2-9 libtwolame0 libudfread0 libv4l-0 libv4lconvert0 libva-drm2 libva-x11-2 libva2 libvdpau1
  libvisual-0.4-0 libvulkan1 libwavpack1 libwayland-server0 libwebkit2gtk-4.0-37 libwebpdemux2 libwebpmux3
  libwebrtc-audio-processing1 libwoff1 libx11-xcb1 libxaw7 libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0
  libxcb-present0 libxcb-randr0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxkbfile1 libxmu6
  libxshmfence1 libxt6 libxv1 libxvidcore4 libxxf86dga1 libxxf86vm1 libzen0v5 libzmq5 libzvbi-common
  libzvbi0 mediainfo mesa-va-drivers mesa-vdpau-drivers mesa-vulkan-drivers ocl-icd-libopencl1
  openjdk-11-jre openjdk-11-jre-headless p7zip p7zip-full pipewire pipewire-bin pipewire-media-session
  rtkit sound-theme-freedesktop unrar va-driver-all vdpau-driver-all x11-utils xdg-dbus-proxy
  xdg-desktop-portal xdg-desktop-portal-gtk zenity zenity-common
0 upgraded, 187 newly installed, 0 to remove and 11 not upgraded.
Need to get 181 MB of archives.
After this operation, 714 MB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
+ filebot -script fn:sysinfo
sh: 25: filebot: not found
```